### PR TITLE
Update default.css

### DIFF
--- a/public/themes/default.css
+++ b/public/themes/default.css
@@ -288,3 +288,6 @@ table.stickyHeaders th {
 	overflow: auto;
 }
 
+.cke_dialog_background_cover {
+	opacity: 0 !important;
+}


### PR DESCRIPTION
This will remove the 50% opacity background on the equation editor.
